### PR TITLE
Avoid colliding with default LSPDFR Traffic Stop menus

### DIFF
--- a/LSPDFR+/EnhancedPursuitAI.cs
+++ b/LSPDFR+/EnhancedPursuitAI.cs
@@ -12,7 +12,7 @@ using Rage.Native;
 namespace LSPDFR_
 {
     public enum PursuitTactics { Safe, SlightlyAggressive, FulloutAggressive }
-    [Obsolete("LSPDFR 0.4 appears to use custom AI rather than pursuit natives, this no longer works unfortunately.")]
+    [Obsolete("LSPDFR 0.4 appears to use custom AI rather than pursuit natives, this no longer works well unless disabling it.")]
     internal static class EnhancedPursuitAI
     {
         

--- a/LSPDFR+/EnhancedPursuitAI.cs
+++ b/LSPDFR+/EnhancedPursuitAI.cs
@@ -12,6 +12,7 @@ using Rage.Native;
 namespace LSPDFR_
 {
     public enum PursuitTactics { Safe, SlightlyAggressive, FulloutAggressive }
+    [Obsolete("LSPDFR 0.4 appears to use custom AI rather than pursuit natives, this no longer works unfortunately.")]
     internal static class EnhancedPursuitAI
     {
         

--- a/LSPDFR+/EnhancedTrafficStop.cs
+++ b/LSPDFR+/EnhancedTrafficStop.cs
@@ -18,7 +18,7 @@ namespace LSPDFR_
     {
         public static bool EnhancedTrafficStopsEnabled = true;
         public static ControllerButtons BringUpTrafficStopMenuControllerButton = ControllerButtons.DPadRight;
-        public static Keys BringUpTrafficStopMenuKey = Keys.E;
+        public static Keys BringUpTrafficStopMenuKey = Keys.D7;
 
         public static TupleList<Ped, string, string> PedsWithCustomTrafficStopQuestionsAndAnswers = new TupleList<Ped, string, string>();
         public static TupleList<Ped, string, Func<Ped, string>> PedsCustomTrafficStopQuestionsAndCallBackAnswer = new TupleList<Ped, string, Func<Ped, string>>();
@@ -104,6 +104,9 @@ namespace LSPDFR_
         {
             if (Functions.IsPlayerPerformingPullover())
             {
+
+                Game.DisplaySubtitle($"Press {BringUpTrafficStopMenuKey} to bring up LSPDFR+ TS m"); //TODO temp temp
+
                 SuspectVehicle = Functions.GetPulloverSuspect(Functions.GetCurrentPullover()).CurrentVehicle;
                 Suspect = Functions.GetPulloverSuspect(Functions.GetCurrentPullover());
                 if (SuspectVehicle.IsBoat)

--- a/LSPDFR+/EnhancedTrafficStop.cs
+++ b/LSPDFR+/EnhancedTrafficStop.cs
@@ -111,7 +111,7 @@ namespace LSPDFR_
                 {
                     string maybeControllerButton = BringUpTrafficStopMenuControllerButton != ControllerButtons.None ? $" or ~o~{BringUpTrafficStopMenuControllerButton}~w~" : "";
 
-                    Game.DisplayNotification($"Press ~b~{BringUpTrafficStopMenuKey}~w~{maybeControllerButton} when standing at the side of the vehicle to bring up the ~g~LSPDFR+ Traffic Stop~w~ menu instead of the normal Traffic Stop menu.");
+                    Game.DisplayNotification($"Press ~b~{BringUpTrafficStopMenuKey.FriendlyName()}~w~{maybeControllerButton} when standing at the side of the vehicle to bring up the ~g~LSPDFR+ Traffic Stop~w~ menu instead of the normal Traffic Stop menu.");
                     HasShownKeybindHelp = true;
                 }
                 

--- a/LSPDFR+/EnhancedTrafficStop.cs
+++ b/LSPDFR+/EnhancedTrafficStop.cs
@@ -27,6 +27,8 @@ namespace LSPDFR_
 
         public static TupleList<Ped, TrafficStopQuestionsInfo> SuspectsTrafficStopQuestionsInfo = new TupleList<Ped, TrafficStopQuestionsInfo>();
 
+        public static bool HasShownKeybindHelp = false;
+
 
         public static void PedBackIntoVehicleLogic(Ped suspect, Vehicle suspectvehicle)
         {
@@ -105,7 +107,14 @@ namespace LSPDFR_
             if (Functions.IsPlayerPerformingPullover())
             {
 
-                Game.DisplaySubtitle($"Press {BringUpTrafficStopMenuKey} to bring up LSPDFR+ TS m"); //TODO temp temp
+                if (!HasShownKeybindHelp)
+                {
+                    string maybeControllerButton = BringUpTrafficStopMenuControllerButton != ControllerButtons.None ? $" or ~o~{BringUpTrafficStopMenuControllerButton}~w~" : "";
+
+                    Game.DisplayNotification($"Press ~b~{BringUpTrafficStopMenuKey}~w~{maybeControllerButton} when standing at the side of the vehicle to bring up the ~g~LSPDFR+ Traffic Stop~w~ menu instead of the normal Traffic Stop menu.");
+                    HasShownKeybindHelp = true;
+                }
+                
 
                 SuspectVehicle = Functions.GetPulloverSuspect(Functions.GetCurrentPullover()).CurrentVehicle;
                 Suspect = Functions.GetPulloverSuspect(Functions.GetCurrentPullover());

--- a/LSPDFR+/EnhancedTrafficStop.cs
+++ b/LSPDFR+/EnhancedTrafficStop.cs
@@ -111,7 +111,7 @@ namespace LSPDFR_
                 {
                     string maybeControllerButton = BringUpTrafficStopMenuControllerButton != ControllerButtons.None ? $" or ~o~{BringUpTrafficStopMenuControllerButton}~w~" : "";
 
-                    Game.DisplayNotification($"Press ~b~{BringUpTrafficStopMenuKey.FriendlyName()}~w~{maybeControllerButton} when standing at the side of the vehicle to bring up the ~g~LSPDFR+ Traffic Stop~w~ menu instead of the normal Traffic Stop menu.");
+                    Game.DisplayNotification($"Press ~b~{BringUpTrafficStopMenuKey.FriendlyName()}~w~{maybeControllerButton} when standing at the side of the vehicle to bring up the ~g~LSPDFR+ Traffic Stop~w~ menu.");
                     HasShownKeybindHelp = true;
                 }
                 

--- a/LSPDFR+/LSPDFR+.csproj
+++ b/LSPDFR+/LSPDFR+.csproj
@@ -121,7 +121,9 @@
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="LSPDFR+.ini" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>REM albo specific copy /Y "$(TargetDir)$(ProjectName).dll" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR

--- a/LSPDFR+/LSPDFR+.csproj
+++ b/LSPDFR+/LSPDFR+.csproj
@@ -64,9 +64,9 @@
     <DocumentationFile>bin\Release\Obfuscation\Confused\LSPDFR+.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Albo1125.Common, Version=6.6.2.0, Culture=neutral, processorArchitecture=AMD64">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Albo1125.Common, Version=6.6.4.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>dependencies\Albo1125.Common.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Arrest Manager, Version=7.9.1.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
@@ -90,6 +90,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />

--- a/LSPDFR+/LSPDFR+.csproj
+++ b/LSPDFR+/LSPDFR+.csproj
@@ -124,8 +124,8 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetDir)$(ProjectName).dll" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR
-copy /Y "$(TargetDir)$(ProjectName).pdb" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR</PostBuildEvent>
+    <PostBuildEvent>REM albo specific copy /Y "$(TargetDir)$(ProjectName).dll" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR
+REM albo specific copy /Y "$(TargetDir)$(ProjectName).pdb" "G:\Program Files\Rockstar Games\Grand Theft Auto V\Plugins\LSPDFR</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/LSPDFR+/LSPDFR+.ini
+++ b/LSPDFR+/LSPDFR+.ini
@@ -1,0 +1,53 @@
+﻿//INI File for LSPDFR+ by Albo1125. Last updated for version 1.6.5.3.
+//Valid keys: use Member Name at https://msdn.microsoft.com/en-us/library/system.windows.forms.keys(v=vs.110).aspx
+[General]
+
+//True/false to enable/disable custom pursuit AI.
+EnhancedPursuitAIEnabled=true
+
+//If true, other AI units will ambiently join the pursuit even if you don't call for them using LSPDFR's backup menu.
+//If false, prevents ambient AI units from joining the pursuit unless you call for them with LSPDFR's backup menu.
+AutoPursuitBackupEnabled=false
+
+//This key only works during pursuits and when you're in a vehicle to minimize conflicts.
+OpenPursuitTacticsMenuKey=Q
+OpenPursuitTacticsMenuModifierKey=LShiftKey
+
+//This key only works when on foot and when near a pedestrian.
+OpenTicketMenuKey=Q
+OpenTicketMenuModifierKey=LShiftKey
+
+// Default key to bring us LSPDFR+'s custom traffic stop menu. Should be different than the default menu, which is 'E'
+BringUpTrafficStopMenuKey=D7
+
+//Possible controller buttons: None, DPadLeft, DPadRight, DPadUp, DPadDown, X, Y, A, B, LeftThumb, RightThumb, LeftShoulder, RightShoulder, Back, Start
+BringUpTrafficStopMenuControllerButton=None
+
+EnhancedTrafficStopsEnabled=true
+
+//If true, sets automatic pursuit AI to be activated when going on duty. This can be altered ingame at any time.
+DefaultAutomaticAI=true
+
+//Set to true or false depending on whether you wish to use the points system for tickets.
+EnablePoints=true
+
+//The maximum amount of points you can give someone for (an) offence(s).
+MaxPoints=12
+
+//The incremental step for the points selection in the menu (1 means 0,1,2,3... and 2 means 0,2,4,6.. etc.).
+PointsIncrementalStep=1
+
+//The currency used to display the fines. If British Policing Script is running, sets this to £ automatically.
+FineCurrency=$
+
+MaxFine=5000
+
+[OnlyWithoutBritishPolicingScriptInstalled]
+//This category's features only work if British Policing Script isn't installed, as British Policing Script replaces these features automatically.
+OpenCourtMenuKey=F9
+
+OpenCourtMenuModifierKey=None
+
+//Setting this to true makes the case hearing take place 1-4 days from the crime date and only during office hours.
+//Setting this to false makes the case hearing take place 2-10 minutes after the crime.
+RealisticCourtDates=true

--- a/LSPDFR+/LSPDFR+.ini
+++ b/LSPDFR+/LSPDFR+.ini
@@ -1,4 +1,4 @@
-﻿//INI File for LSPDFR+ by Albo1125. Last updated for version 1.6.5.3.
+﻿//INI File for LSPDFR+ by Albo1125. Last updated for version 1.8.0.0.
 //Valid keys: use Member Name at https://msdn.microsoft.com/en-us/library/system.windows.forms.keys(v=vs.110).aspx
 [General]
 
@@ -17,11 +17,12 @@ OpenPursuitTacticsMenuModifierKey=LShiftKey
 OpenTicketMenuKey=Q
 OpenTicketMenuModifierKey=LShiftKey
 
-// Default key to bring us LSPDFR+'s custom traffic stop menu. Should be different than the default menu, which is 'E'
-BringUpTrafficStopMenuKey=D7
+// Default key to bring us LSPDFR+'s custom traffic stop menu. Should be different than the default menu (change TRAFFICSTOP_INTERACT_Key to None in lspdfr/keys.ini)
+BringUpTrafficStopMenuKey=E
 
 //Possible controller buttons: None, DPadLeft, DPadRight, DPadUp, DPadDown, X, Y, A, B, LeftThumb, RightThumb, LeftShoulder, RightShoulder, Back, Start
-BringUpTrafficStopMenuControllerButton=None
+//Should be different than the default menu (change TRAFFICSTOP_INTERACT_ControllerKey to None in lspdfr/keys.ini)
+BringUpTrafficStopMenuControllerButton=DPadRight
 
 EnhancedTrafficStopsEnabled=true
 

--- a/LSPDFR+/LSPDFR+.ini
+++ b/LSPDFR+/LSPDFR+.ini
@@ -2,8 +2,8 @@
 //Valid keys: use Member Name at https://msdn.microsoft.com/en-us/library/system.windows.forms.keys(v=vs.110).aspx
 [General]
 
-//True/false to enable/disable custom pursuit AI.
-EnhancedPursuitAIEnabled=true
+//True/false to enable/disable custom pursuit AI. Default to off (false) in LSPDFR 0.4.
+EnhancedPursuitAIEnabled=false
 
 //If true, other AI units will ambiently join the pursuit even if you don't call for them using LSPDFR's backup menu.
 //If false, prevents ambient AI units from joining the pursuit unless you call for them with LSPDFR's backup menu.

--- a/LSPDFR+/LSPDFRPlusHandler.cs
+++ b/LSPDFR+/LSPDFRPlusHandler.cs
@@ -48,7 +48,43 @@ namespace LSPDFR_
             try
             {
                 EnhancedTrafficStop.BringUpTrafficStopMenuControllerButton = ini.ReadEnum<ControllerButtons>("General", "BringUpTrafficStopMenuControllerButton", ControllerButtons.DPadRight);
-                EnhancedTrafficStop.BringUpTrafficStopMenuKey = (Keys)kc.ConvertFromString(ini.ReadString("General", "BringUpTrafficStopMenuKey", "E"));
+                EnhancedTrafficStop.BringUpTrafficStopMenuKey = (Keys)kc.ConvertFromString(ini.ReadString("General", "BringUpTrafficStopMenuKey", "D7"));
+
+
+                Keys stockTrafficStopInteractKey = Keys.E;
+                Keys stockTrafficStopInteractModifierKey = Keys.None;
+                ControllerButtons stockTrafficStopInteractControllerButton = ControllerButtons.DPadRight;
+                try
+                {
+                    InitializationFile stockLSPDFRIni = new InitializationFile(Path.Combine("lspdfr", "keys.ini"));
+                    stockTrafficStopInteractKey = stockLSPDFRIni.ReadEnum<Keys>("", "TRAFFICSTOP_INTERACT_Key", Keys.E);
+                    stockTrafficStopInteractModifierKey = stockLSPDFRIni.ReadEnum<Keys>("", "TRAFFICSTOP_INTERACT_ModifierKey", Keys.None);
+                    stockTrafficStopInteractControllerButton = ControllerButtons.DPadRight;
+                }
+                catch (Exception e)
+                {
+                    Game.LogTrivial($"Failed to determine stock LSPDFR key bind for TRAFFICSTOP_INTERACT_Key: {e}");
+                }
+
+                if (EnhancedTrafficStop.BringUpTrafficStopMenuKey == stockTrafficStopInteractKey && stockTrafficStopInteractModifierKey == Keys.None)
+                {
+                    Game.DisplayNotification("Your ~g~LSPDFR+ Traffic Stop~w~ key is the same as for the default LSPDFR Traffic Stop. This will cause ~r~problems~w~.");
+                    if (stockTrafficStopInteractKey != Keys.D7) {
+                        EnhancedTrafficStop.BringUpTrafficStopMenuKey = Keys.D7;
+                        Game.DisplayNotification("The LSPDFR+ Traffic Stop key was set to ~y~'7'~w~ on the keyboard, above the letters.");
+                    }
+                    else
+                    {
+                        Game.DisplayNotification("Please change BringUpTrafficStopMenuKey in LSPDFR+.ini.");
+                    }
+                    
+                }
+                if (EnhancedTrafficStop.BringUpTrafficStopMenuControllerButton == stockTrafficStopInteractControllerButton)
+                {
+                    Game.DisplayNotification("Your ~g~LSPDFR+ Traffic Stop~w~ controller button is the same as for the default LSPDFR Traffic Stop. This will cause ~r~problems~w~.");
+                    Game.DisplayNotification("The controller button has been disabled for the ~g~LSPDFR+ Traffic Stop~w~ menu. Please change LSPDFR+.ini if you wish to use a different button");
+                }
+
                 CourtSystem.OpenCourtMenuKey = (Keys)kc.ConvertFromString(ini.ReadString("OnlyWithoutBritishPolicingScriptInstalled", "OpenCourtMenuKey", "F9"));
                 CourtSystem.OpenCourtMenuModifierKey = (Keys)kc.ConvertFromString(ini.ReadString("OnlyWithoutBritishPolicingScriptInstalled", "OpenCourtMenuModifierKey", "None"));
                 EnhancedTrafficStop.EnhancedTrafficStopsEnabled = ini.ReadBoolean("General", "EnhancedTrafficStopsEnabled", true);

--- a/LSPDFR+/LSPDFRPlusHandler.cs
+++ b/LSPDFR+/LSPDFRPlusHandler.cs
@@ -198,7 +198,7 @@ namespace LSPDFR_
 
                 CourtSystem.CourtSystemMainLogic();
                 
-                EnhancedPursuitAI.MainLoop();
+                //EnhancedPursuitAI.MainLoop();
                 StatisticsCounter.AddCountToStatistic("Times gone on duty", "LSPDFR+");
                 
                 Game.LogTrivial("LSPDFR+ has been fully initialised successfully and is now working.");

--- a/LSPDFR+/LSPDFRPlusHandler.cs
+++ b/LSPDFR+/LSPDFRPlusHandler.cs
@@ -198,7 +198,7 @@ namespace LSPDFR_
 
                 CourtSystem.CourtSystemMainLogic();
                 
-                //EnhancedPursuitAI.MainLoop();
+                EnhancedPursuitAI.MainLoop();
                 StatisticsCounter.AddCountToStatistic("Times gone on duty", "LSPDFR+");
                 
                 Game.LogTrivial("LSPDFR+ has been fully initialised successfully and is now working.");

--- a/LSPDFR+/Main.cs
+++ b/LSPDFR+/Main.cs
@@ -35,7 +35,7 @@ namespace LSPDFR_
 
         }
 
-        internal static Version Albo1125CommonVer = new Version("6.6.2.0");
+        internal static Version Albo1125CommonVer = new Version("6.6.4.0");
         internal static Version MadeForGTAVersion = new Version("1.0.1493.1");
         internal static float MinimumRPHVersion = 0.51f;
         internal static string[] AudioFilesToCheckFor = new string[] { };

--- a/LSPDFR+/Main.cs
+++ b/LSPDFR+/Main.cs
@@ -35,13 +35,13 @@ namespace LSPDFR_
 
         }
 
-        internal static Version Albo1125CommonVer = new Version("6.6.4.0");
-        internal static Version MadeForGTAVersion = new Version("1.0.1493.1");
+        internal static Version Albo1125CommonVer = new Version("6.6.3.0");
+        internal static Version MadeForGTAVersion = new Version("1.0.1604.1");
         internal static float MinimumRPHVersion = 0.51f;
         internal static string[] AudioFilesToCheckFor = new string[] { };
         internal static string[] OtherFilesToCheckFor = new string[] {  }; //"Plugins/LSPDFR/LSPDFR+/CourtCases.xml"
         internal static Version RAGENativeUIVersion = new Version("1.6.3.0");
-        internal static Version MadeForLSPDFRVersion = new Version("0.3.38.5436");
+        internal static Version MadeForLSPDFRVersion = new Version("0.4.39.22580");
 
         internal static string DownloadURL = "https://www.lcpdfr.com/files/file/11930-lspdfr-improved-pursuit-ai-better-traffic-stops-court-system/";
 

--- a/LSPDFR+/Main.cs
+++ b/LSPDFR+/Main.cs
@@ -35,7 +35,7 @@ namespace LSPDFR_
 
         }
 
-        internal static Version Albo1125CommonVer = new Version("6.6.3.0");
+        internal static Version Albo1125CommonVer = new Version("6.6.4.0");
         internal static Version MadeForGTAVersion = new Version("1.0.1604.1");
         internal static float MinimumRPHVersion = 0.51f;
         internal static string[] AudioFilesToCheckFor = new string[] { };

--- a/LSPDFR+/Menus.cs
+++ b/LSPDFR+/Menus.cs
@@ -676,7 +676,7 @@ namespace LSPDFR_
                         Vector3.Distance2D(Game.LocalPlayer.Character.Position, pulloverSuspect.CurrentVehicle.Position) < TrafficStopMenuDistance + 0.1f
                         )
                     {
-                        ExtensionNamespace.Extensions.DisEnableControls(false);
+                        //ExtensionNamespace.Extensions.DisEnableControls(false);
                         //ExtensionNamespace.Extensions.DisableTrafficStopControls();
 
                         if (ExtensionMethods.IsKeyDownComputerCheck(EnhancedTrafficStop.BringUpTrafficStopMenuKey) || Game.IsControllerButtonDown(EnhancedTrafficStop.BringUpTrafficStopMenuControllerButton))

--- a/LSPDFR+/Menus.cs
+++ b/LSPDFR+/Menus.cs
@@ -137,7 +137,6 @@ namespace LSPDFR_
             //ChecksMenu = new UIMenu("Checks", "");
             //_MenuPool.Add(ChecksMenu);
             TrafficStopMenu = new UIMenu("LSPDFR+ Traffic Stop", "");
-            TrafficStopMenu.SetMenuWidthOffset(500);
             _MenuPool.Add(TrafficStopMenu);
             TicketMenu = new UIMenu("Ticket", "");
             _MenuPool.Add(TicketMenu);
@@ -249,7 +248,7 @@ namespace LSPDFR_
 
             QuestioningMenu.MouseControlsEnabled = false;
             QuestioningMenu.AllowCameraMovement = true;
-            QuestioningMenu.SetMenuWidthOffset(110);
+            QuestioningMenu.SetMenuWidthOffset(120);
 
             CourtsMenu = new TabView("~b~~h~San Andreas Court");
 

--- a/LSPDFR+/Menus.cs
+++ b/LSPDFR+/Menus.cs
@@ -136,7 +136,7 @@ namespace LSPDFR_
             _MenuPool = new MenuPool();
             //ChecksMenu = new UIMenu("Checks", "");
             //_MenuPool.Add(ChecksMenu);
-            TrafficStopMenu = new UIMenu("Traffic Stop", "");
+            TrafficStopMenu = new UIMenu("LSPDFR+ Traffic Stop", "");
             _MenuPool.Add(TrafficStopMenu);
             TicketMenu = new UIMenu("Ticket", "");
             _MenuPool.Add(TicketMenu);
@@ -665,35 +665,43 @@ namespace LSPDFR_
         private static bool CourtsMenuPaused = false;
         private static void Process(object sender, GraphicsEventArgs e)
         {
-            if (Functions.IsPlayerPerformingPullover() && !_MenuPool.IsAnyMenuOpen() && EnhancedTrafficStop.EnhancedTrafficStopsEnabled)
+            try
             {
-                if (Vector3.Distance2D(Game.LocalPlayer.Character.Position, Functions.GetPulloverSuspect(Functions.GetCurrentPullover()).CurrentVehicle.Position) < TrafficStopMenuDistance + 0.1f)
+                if (Functions.IsPlayerPerformingPullover() && !_MenuPool.IsAnyMenuOpen() && EnhancedTrafficStop.EnhancedTrafficStopsEnabled)
                 {
-                    ExtensionNamespace.Extensions.DisEnableControls(false);
-                    //ExtensionNamespace.Extensions.DisableTrafficStopControls();
-
-                    if (ExtensionMethods.IsKeyDownComputerCheck(EnhancedTrafficStop.BringUpTrafficStopMenuKey) || Game.IsControllerButtonDown(EnhancedTrafficStop.BringUpTrafficStopMenuControllerButton))
+                    if (Vector3.Distance2D(Game.LocalPlayer.Character.Position, Functions.GetPulloverSuspect(Functions.GetCurrentPullover()).CurrentVehicle.Position) < TrafficStopMenuDistance + 0.1f)
                     {
-                        _MenuPool.ResetMenus(true, true);
-                        SeizeVehicleTicketCheckboxItem.Enabled = true;
-                        TicketMenu.ParentMenu = TrafficStopMenu;
-                        TicketMenu.Visible = false;
-                        foreach (UIMenu m in OffenceCategoryMenus)
-                        {
-                            m.Visible = false;
-                        }
-                        TrafficStopMenu.Visible = true;
+                        ExtensionNamespace.Extensions.DisEnableControls(false);
+                        //ExtensionNamespace.Extensions.DisableTrafficStopControls();
 
+                        if (ExtensionMethods.IsKeyDownComputerCheck(EnhancedTrafficStop.BringUpTrafficStopMenuKey) || Game.IsControllerButtonDown(EnhancedTrafficStop.BringUpTrafficStopMenuControllerButton))
+                        {
+                            _MenuPool.ResetMenus(true, true);
+                            SeizeVehicleTicketCheckboxItem.Enabled = true;
+                            TicketMenu.ParentMenu = TrafficStopMenu;
+                            TicketMenu.Visible = false;
+                            foreach (UIMenu m in OffenceCategoryMenus)
+                            {
+                                m.Visible = false;
+                            }
+                            TrafficStopMenu.Visible = true;
+
+                        }
                     }
                 }
-            }          
 
-            _MenuPool.ProcessMenus();
-            if (CourtsMenu.Visible)
-            {
-                Game.IsPaused = true;
-                CourtsMenu.Update();
+                _MenuPool.ProcessMenus();
+                if (CourtsMenu.Visible)
+                {
+                    Game.IsPaused = true;
+                    CourtsMenu.Update();
+                }
             }
+            catch (Exception exception)
+            {
+                Game.LogTrivial($"Handled {exception}");
+            }
+           
         }
 
         private static void ToggleUIMenuEnabled(UIMenu menu, bool Enabled)

--- a/LSPDFR+/Menus.cs
+++ b/LSPDFR+/Menus.cs
@@ -137,6 +137,7 @@ namespace LSPDFR_
             //ChecksMenu = new UIMenu("Checks", "");
             //_MenuPool.Add(ChecksMenu);
             TrafficStopMenu = new UIMenu("LSPDFR+ Traffic Stop", "");
+            TrafficStopMenu.SetMenuWidthOffset(500);
             _MenuPool.Add(TrafficStopMenu);
             TicketMenu = new UIMenu("Ticket", "");
             _MenuPool.Add(TicketMenu);

--- a/LSPDFR+/Menus.cs
+++ b/LSPDFR+/Menus.cs
@@ -670,7 +670,11 @@ namespace LSPDFR_
             {
                 if (Functions.IsPlayerPerformingPullover() && !_MenuPool.IsAnyMenuOpen() && EnhancedTrafficStop.EnhancedTrafficStopsEnabled)
                 {
-                    if (Vector3.Distance2D(Game.LocalPlayer.Character.Position, Functions.GetPulloverSuspect(Functions.GetCurrentPullover()).CurrentVehicle.Position) < TrafficStopMenuDistance + 0.1f)
+                    Ped pulloverSuspect = Functions.GetPulloverSuspect(Functions.GetCurrentPullover());
+                    if (pulloverSuspect &&
+                        pulloverSuspect.IsInAnyVehicle(false) &&
+                        Vector3.Distance2D(Game.LocalPlayer.Character.Position, pulloverSuspect.CurrentVehicle.Position) < TrafficStopMenuDistance + 0.1f
+                        )
                     {
                         ExtensionNamespace.Extensions.DisEnableControls(false);
                         //ExtensionNamespace.Extensions.DisableTrafficStopControls();

--- a/LSPDFR+/Properties/AssemblyInfo.cs
+++ b/LSPDFR+/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Albo1125")]
 [assembly: AssemblyProduct("LSPDFR+")]
-[assembly: AssemblyCopyright("Copyright ©  2016-2018 - Albo1125")]
+[assembly: AssemblyCopyright("Copyright ©  2016-2019 - Albo1125")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("1.8.0.0")]
+[assembly: AssemblyFileVersion("1.8.0.0")]


### PR DESCRIPTION
Switch default keybinds, avoid colliding with default keybinds. Short-term solution for continuing to have LSPDFR+'s excellent additional features in 0.4. Also add INI file and disable enhanced pursuit AI on 0.4 (unknown effect as I have not tested it at this time)