### PR TITLE
lspdfr_ver_0_4_2: Updated expected LSPDFR Version to 0.4.2

### DIFF
--- a/LSPDFR+/Main.cs
+++ b/LSPDFR+/Main.cs
@@ -41,7 +41,7 @@ namespace LSPDFR_
         internal static string[] AudioFilesToCheckFor = new string[] { };
         internal static string[] OtherFilesToCheckFor = new string[] {  }; //"Plugins/LSPDFR/LSPDFR+/CourtCases.xml"
         internal static Version RAGENativeUIVersion = new Version("1.6.3.0");
-        internal static Version MadeForLSPDFRVersion = new Version("0.4.39.22580");
+        internal static Version MadeForLSPDFRVersion = new Version("0.4.2");
 
         internal static string DownloadURL = "https://www.lcpdfr.com/files/file/11930-lspdfr-improved-pursuit-ai-better-traffic-stops-court-system/";
 


### PR DESCRIPTION
The DLL (both getVersion() and DLL product info) reports version 0.4.2. Just a simple change to get my foot in the door (and checking if this repo is still active)